### PR TITLE
Use CommonMark

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "jekyll", "~> 3.8.6"
+
+group :jekyll_plugins do
+  gem 'jekyll-commonmark'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,8 @@ GEM
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     colorator (1.1.0)
+    commonmarker (0.20.1)
+      ruby-enum (~> 0.5)
     concurrent-ruby (1.1.5)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
@@ -35,6 +37,9 @@ GEM
       pathutil (~> 0.9)
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
+    jekyll-commonmark (1.3.1)
+      commonmarker (~> 0.14)
+      jekyll (>= 3.7, < 5.0)
     jekyll-feed (0.12.1)
       jekyll (>= 3.7, < 5.0)
     jekyll-sass-converter (1.5.2)
@@ -57,6 +62,8 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     rouge (3.7.0)
+    ruby-enum (0.7.2)
+      i18n
     ruby_dep (1.5.0)
     safe_yaml (1.0.5)
     sass (3.7.4)
@@ -71,6 +78,7 @@ PLATFORMS
 DEPENDENCIES
   bundler
   jekyll (~> 3.8.6)
+  jekyll-commonmark
   kids!
 
 BUNDLED WITH

--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Mick F
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Kids
+
+Kids is a Jekyll theme.
+
+## Installation
+
+To use the Kids theme:
+
+1. Add the following to your site's `Gemfile`:
+
+   ```ruby
+   gem "kids", git: "https://github.com/dirtyhenry/kids.git", branch: 'master'
+   ```
+
+1. Add the following to your site's `_config.yml`:
+
+   ```yml
+   theme: kids
+   ```
+
+## Contributing
+
+Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+
+Please make sure to update tests as appropriate.
+
+## License
+
+[MIT](https://choosealicense.com/licenses/mit/)

--- a/_config.yml
+++ b/_config.yml
@@ -15,10 +15,11 @@ footer_pages:
   - footer.md
 
 show_excerpts: true
+markdown: CommonMark
 
 kids:
   # The path to the page using the archives template
-  archives_path: 'archives.html'
+  archives_path: "archives.html"
   # The maximal number of posts featured on the home
   home_posts: 5
 
@@ -26,8 +27,8 @@ kids:
 theme: kids
 
 plugins:
- - jekyll-feed
- - jekyll-seo-tag
+  - jekyll-feed
+  - jekyll-seo-tag
 
 exclude:
   - Gemfile


### PR DESCRIPTION
This PR is replacing Jekyll's default Markdown renderer for CommonMark.

It also opportunistically adds a README file and a MIT License to the project. 