### PR TITLE
Fix padding issues in lists within block quotes and extra-padding in metadata block

### DIFF
--- a/_posts/2019-10-10-typography.md
+++ b/_posts/2019-10-10-typography.md
@@ -38,7 +38,12 @@ This is a list:
 
 Another paragraph.
 
-> This is another quote.  
+> This is another quote, with a list:
+>
+> 1. One
+> 2. Two
+> 3. Three
+>
 > — Whoever said it
 
 And a closing paragraph.

--- a/_sass/kids/_typography.scss
+++ b/_sass/kids/_typography.scss
@@ -31,6 +31,7 @@ main {
     }
 
     ul.authors-list {
+      padding: 0;
       margin: 0;
       list-style-type: none;
       display: inline-block;

--- a/_sass/kids/_typography.scss
+++ b/_sass/kids/_typography.scss
@@ -64,6 +64,14 @@ main {
         text-indent: 0;
       }
     }
+
+    @media (min-width: 1024px) {
+      & > ul,
+      & > ol {
+        padding-left: 0;
+        list-style-position: outside;
+      }
+    }
   }
 
   p ~ div,
@@ -79,14 +87,6 @@ main {
 
   li > ul {
     padding-left: 2rem;
-  }
-
-  @media (min-width: 1024px) {
-    ul,
-    ol {
-      padding-left: 0;
-      list-style-position: outside;
-    }
   }
 }
 


### PR DESCRIPTION
This PR fixes these 2 bugs:

* Misalignment of lists within block quotes: 

<img width="331" alt="Screen Shot 2020-09-25 at 14 49 07" src="https://user-images.githubusercontent.com/456506/94269434-f0ba0700-ff3e-11ea-8d3d-c995c02fcf4a.png">

* Extra-padding in metadata block

<img width="561" alt="Screen Shot 2020-09-25 at 14 49 00" src="https://user-images.githubusercontent.com/456506/94269437-f1529d80-ff3e-11ea-92ca-68644c4c2f19.png">
