### PR TITLE
Stop using indented paragraphs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on: [push]
+jobs:
+  lighthouseci:
+    name: Lighthouse CI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: "2.7"
+      - run: npm install -g @lhci/cli@0.8.x
+      - run: JEKYLL_ENV=production make install build
+      - run: lhci autorun

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+_includes/*.html
+_layouts/*.html

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,10 @@ group :jekyll_plugins do
       git: 'https://github.com/jekyll/jekyll-archives.git',
       branch: 'master'
 
+  gem 'jekyll-commonmark',
+      git: 'https://github.com/jekyll/jekyll-commonmark.git',
+      branch: 'master'
+
   gem 'buckygem',
       git: 'https://github.com/dirtyhenry/buckygem.git',
       branch: 'main'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,14 @@ GIT
     jekyll-archives (2.2.1)
       jekyll (>= 3.6, < 5.0)
 
+GIT
+  remote: https://github.com/jekyll/jekyll-commonmark.git
+  revision: 37e262a5635e74f2a2a4b1233f91cf49ac29ee7f
+  branch: master
+  specs:
+    jekyll-commonmark (1.3.1)
+      commonmarker (~> 0.22)
+
 PATH
   remote: .
   specs:
@@ -50,7 +58,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.4.1)
+    activesupport (6.1.4.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -69,7 +77,7 @@ GEM
     execjs (2.8.1)
     extras (0.3.0)
       forwardable-extended (~> 2.5)
-    fastimage (2.2.5)
+    fastimage (2.2.6)
     ffi (1.15.4)
     forwardable-extended (2.6.0)
     http_parser.rb (0.8.0)
@@ -90,9 +98,6 @@ GEM
       rouge (~> 3.0)
       safe_yaml (~> 1.0)
       terminal-table (~> 2.0)
-    jekyll-commonmark (1.3.1)
-      commonmarker (~> 0.14)
-      jekyll (>= 3.7, < 5.0)
     jekyll-feed (0.15.1)
       jekyll (>= 3.7, < 5.0)
     jekyll-sanity (1.6.0)
@@ -118,12 +123,12 @@ GEM
     mercenary (0.4.0)
     mini_magick (4.11.0)
     mini_portile2 (2.6.1)
-    minitest (5.14.4)
+    minitest (5.15.0)
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
     parallel (1.21.0)
-    parser (3.0.2.0)
+    parser (3.0.3.2)
       ast (~> 2.4.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
@@ -134,9 +139,9 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    regexp_parser (2.1.1)
+    regexp_parser (2.2.0)
     rexml (3.2.5)
-    rouge (3.26.1)
+    rouge (3.27.0)
     rubocop (1.23.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
@@ -146,7 +151,7 @@ GEM
       rubocop-ast (>= 1.12.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.13.0)
+    rubocop-ast (1.15.0)
       parser (>= 3.0.1.1)
     ruby-progressbar (1.11.0)
     safe_yaml (1.0.5)
@@ -170,6 +175,7 @@ DEPENDENCIES
   bundler (~> 2.0)
   jekyll-archives!
   jekyll-assets!
+  jekyll-commonmark!
   kids!
   rubocop (~> 1.6)
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,10 +13,6 @@
 
   <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
 
-  {%- if jekyll.environment != 'production' -%}
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/checka11y-css@1.2.0/checka11y.css" />
-  {%- endif -%}
-
   {%- feed_meta -%}
   {%- if jekyll.environment == 'production' and site.google_analytics -%}
     {%- include google-analytics.html -%}

--- a/_posts/2019-10-10-typography.md
+++ b/_posts/2019-10-10-typography.md
@@ -18,7 +18,7 @@ A leading paragraph.
 Another paragraph about things, so that we can have a text long enough to
 overflow a single line.
 
-The following paragraph will be indented a little to improve readability.
+The following paragraph will be separated a little to improve readability.
 
 ## A list
 

--- a/_posts/2020-04-05-images.md
+++ b/_posts/2020-04-05-images.md
@@ -16,7 +16,7 @@ Bla bli blou
 
 A parapraph before the image.
 
-{% asset keith-misner-h0Vxgz5tyXA-unsplash.jpg %}
+{% asset keith-misner-h0Vxgz5tyXA-unsplash.jpg alt="A random photo from Unsplash" %}
 
 A parapraph after the image.
 

--- a/_sass/kids/_base.scss
+++ b/_sass/kids/_base.scss
@@ -1,5 +1,5 @@
-body {
-  // Remove the default margin in browsers
+// Remove all default margin
+* {
   margin: 0;
 }
 

--- a/_sass/kids/_typography.scss
+++ b/_sass/kids/_typography.scss
@@ -48,13 +48,9 @@ main {
     }
   }
 
-  p {
-    margin: 0 auto;
-  }
-
   .post-content {
     p + p {
-      text-indent: 1em;
+      margin-top: 1rem;
     }
 
     blockquote {

--- a/kids.gemspec
+++ b/kids.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
     f.match(%r{^(assets|_(includes|layouts|sass)/|(LICENSE|README)((\.(txt|md|markdown)|$)))}i)
   end
 
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 2.7'
 
   spec.add_runtime_dependency 'buckygem', '~> 0.5'
   spec.add_runtime_dependency 'jekyll', '>= 4.0', '< 5.0'
@@ -28,4 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rubocop', '~> 1.6'
+  spec.metadata = {
+    'rubygems_mfa_required' => 'true'
+  }
 end


### PR DESCRIPTION
- build: fix build errors and run rubocop
- ci: run lighthouse in CI
- build: ignore Liquid files when using Prettier
- ci: stop using checka11y.css and use Lighthouse CI instead
- feat: stop using indent for paragraphs

---

The main point of this PR was to remove the paragraph indentation but:

- the projet wouldn't build at first after a `bundle update`;
- I was frustrated with reports from `checka11y.css` while testing for regressions so I wanted to give Lighthouse CI a try instead;
- I removed margins globally, inspired by Josh Comeau reset style.
